### PR TITLE
Change `discretize()` output dataframe to be one-hot encoded on `continuous_cols`

### DIFF
--- a/discretize.R
+++ b/discretize.R
@@ -65,6 +65,18 @@ discretize <- function(X, y, threshold = 0.01, continuous_cols, n_quantiles = NU
       }
     }
   }
+  
+  # Change bucketized columns to be one-hot encoded
+  for (col in continuous_cols) {
+    # Generate one-hot encoded matrix for the column
+    one_hot <- model.matrix(~ factor(X[[col]]) - 1)  # - 1 removes the intercept 
+    colnames(one_hot) <- paste(col, levels(factor(X[[col]])), sep = "_")
+    
+    # Add the new columns and remove the old one
+    X <- cbind(X, one_hot)
+    X[[col]] <- NULL
+  }
+  
   return(X)
 }
 

--- a/test_discretize.Rmd
+++ b/test_discretize.Rmd
@@ -88,9 +88,9 @@ cont_cols <- c("self_eff", "tx_mos", "stig_tot",
 
 
 ```{r, warning=FALSE}
-disc_X_10 <- discretize(X, y, continuous_cols = cont_var)
-disc_X_5 <- discretize(X, y, continuous_cols = cont_var, n_quantiles = rep(5, length(cont_var)))
-disc_X_3 <- discretize(X, y, continuous_cols = cont_var, n_quantiles = rep(3, length(cont_var)))
+disc_X_10 <- discretize(X, y, continuous_cols = cont_cols)
+disc_X_5 <- discretize(X, y, continuous_cols = cont_cols, n_quantiles = rep(5, length(cont_cols)))
+disc_X_3 <- discretize(X, y, continuous_cols = cont_cols, n_quantiles = rep(3, length(cont_cols)))
 ```
 
 ```{r, warning=FALSE}
@@ -118,12 +118,12 @@ res3 <- get_results(disc_X_3)
 ```
 
 ```{r, warning=FALSE}
-t01q10 <- get_results(discretize(X, y, continuous_cols = cont_var))
-t05q10 <- get_results(discretize(X, y, continuous_cols = cont_var,  
+t01q10 <- get_results(discretize(X, y, continuous_cols = cont_cols))
+t05q10 <- get_results(discretize(X, y, continuous_cols = cont_cols,  
                                  threshold = 0.05))
-t001q10 <- get_results(discretize(X, y, continuous_cols = cont_var,
+t001q10 <- get_results(discretize(X, y, continuous_cols = cont_cols,
                                   threshold = 0.001))
-t005q10 <- get_results(discretize(X, y, continuous_cols = cont_var,  
+t005q10 <- get_results(discretize(X, y, continuous_cols = cont_cols,  
                                  threshold = 0.005))
 ```
 

--- a/test_discretize.Rmd
+++ b/test_discretize.Rmd
@@ -10,7 +10,6 @@ floor_median <- function(x) {
 preprocess <- function(data) {
   # define binary outcome (y)
   data$adherence_outcome <- ifelse(data$PCTadherence_sensi < 95, 1, 0)
-  print(data$adherence_outcome)
   
   # drop subsequent regimens
   data <- data %>%


### PR DESCRIPTION
# Changes Implemented
- Bug fixes in test script
- Transform `continuous_cols` from buckets (ex. 1 through 6) to a one-hot encoding (ex. a row such as 010000, 100000, 000100)